### PR TITLE
Restock fix

### DIFF
--- a/Stock/StockedShop.cs
+++ b/Stock/StockedShop.cs
@@ -293,7 +293,7 @@ public abstract class StockedShop : ModType
         {
             Condition = AlwaysTrue;
             Item = item;
-            Item.isAShopItem = true;
+            Item.buyOnce = true;
         }
 
         /// <summary>


### PR DESCRIPTION
Items that are added to "stock" were directly from FullStock, which means that modifies to items in stock would also influence that in FullStack. To fix this, I clone the item when transfer it from FullStock to stock.
And when items are sold out, the "stock" would be empty, and it would make ShouldRestockShop() return true and cause restock.