### PR TITLE
Price fix

### DIFF
--- a/Stock/StockHooks.cs
+++ b/Stock/StockHooks.cs
@@ -1,0 +1,152 @@
+﻿using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using System;
+using Terraria;
+using Terraria.ModLoader;
+using Terraria.UI;
+using Terraria.UI.Chat;
+
+namespace StockableShops.Stock;
+
+internal class StockHooks : ModSystem
+{
+    #region decrease the stocked stack when buying an item
+    private static VariableDefinition DeclareLocal<T>(ILContext il) => DeclareLocal(il, typeof(T));
+    private static VariableDefinition DeclareLocal(ILContext il, Type type)
+    {
+        VariableDefinition result = new(il.Method.DeclaringType.Module.ImportReference(type));
+        il.Body.Variables.Add(result);
+        return result;
+    }
+
+    private static void OnBoughtInSlotHook(ILContext il)
+    {
+        ILCursor cursor = new(il);
+
+        cursor.GotoNext(MoveType.After, i => i.MatchCall(typeof(ItemSlot), nameof(ItemSlot.RefreshStackSplitCooldown)));
+        cursor.EmitLdarg0();
+        cursor.EmitLdarg1();
+        cursor.EmitLdelemRef();
+        cursor.EmitLdloc(5);    // boughtItem
+        cursor.EmitDelegate(OnBoughtInShopInner);
+    }
+    /// <summary>
+    /// <br/>midify item in shop when bought
+    /// <br/>called on every single buy
+    /// </summary>
+    private static void OnBoughtInShopInner(Item itemInShop, Item boughtItem)
+    {
+        var stockedItem = itemInShop.GetGlobalItem<StockedItem>();
+        if (!stockedItem.Stockable)
+            return;
+        stockedItem.Stack -= 1;
+        boughtItem.GetGlobalItem<StockedItem>().Stockable = false;
+    }
+    #endregion
+
+    #region increase the stocked stack when selling back
+    private static void SellbackItemHook(ILContext il)
+    {
+        ILCursor cursor = new(il);
+        cursor.GotoNext(MoveType.After, i => i.MatchStloc0());
+        cursor.EmitLdarg0();
+        cursor.EmitLdarg1();
+        cursor.EmitLdloc0();
+        cursor.EmitDelegate(HandleShopSellBackNum);
+    }
+    private static void HandleShopSellBackNum(Chest chest, Item newItem, int removed)
+    {
+        if (removed <= 0)
+        {
+            return;
+        }
+        for (int i = 0; i < chest.item.Length; ++i)
+        {
+            if (chest.item[i] != null && chest.item[i].type == newItem.type)
+            {
+                var stockedItem = chest.item[i].GetGlobalItem<StockedItem>();
+                if (!stockedItem.Stockable)
+                {
+                    continue;
+                }
+                stockedItem.Stack += removed;
+                return;
+            }
+        }
+    }
+    #endregion
+
+    #region make an item unavailable to buy when stocked stack is zero
+    private class BuyLimitForPlayer : ModPlayer
+    {
+        public override bool CanBuyItem(NPC vendor, Item[] shopInventory, Item item)
+        {
+            var stockedItem = item.GetGlobalItem<StockedItem>();
+            return !stockedItem.Stockable || stockedItem.Stack > 0;
+        }
+    }
+    #endregion
+
+    #region draw stocked stack
+    private static void DrawStockedStackHook(ILContext il)
+    {
+        static bool MatchChatManagerDrawColorString(Instruction i)
+        {
+            return i.MatchCall(typeof(ChatManager), nameof(ChatManager.DrawColorCodedStringWithShadow));
+        }
+        ILCursor cursor = new(il);
+        cursor.GotoNext(
+            i => i.MatchLdloc1(),
+            i => i.MatchLdfld(typeof(Item), nameof(Item.stack)),
+            i => i.MatchLdcI4(1),
+            i => i.MatchBle(out _)
+        );
+        cursor.GotoNext(MatchChatManagerDrawColorString);
+        cursor.GotoPrev(MoveType.AfterLabel,
+            i => i.MatchLdloc1(),
+            i => i.MatchLdfld(typeof(Item), nameof(Item.stack)),
+            i => i.MatchLdcI4(1),
+            i => i.MatchBle(out _)
+        );
+        // cursor now should be before "if (stack > 1)"
+
+        // cursor2 moves after "if (stack > 1)"
+        ILCursor cursor2 = new(cursor);
+        cursor2.GotoNext(MoveType.After, i => i.MatchBle(out _));
+
+        // if the item is stockable, jump the stack check to force draw the stack
+        cursor.EmitLdloc1();
+        cursor.EmitDelegate((Item i) => i.GetGlobalItem<StockedItem>().Stockable);
+        cursor.EmitBrtrue(cursor2.Next!);
+
+        // cursor moves after the check
+        cursor = cursor2;
+        cursor.MoveAfterLabels();
+
+        var origStack = DeclareLocal<int>(il);
+
+        // temporarily change the item stack into stocked stack
+        cursor.EmitLdloc1();
+        cursor.EmitDelegate((Item i) =>
+        {
+            var stack = i.stack;
+            i.stack = i.GetGlobalItem<StockedItem>().Stack;
+            return stack;
+        });
+        cursor.EmitStloc(origStack);
+
+        // revert the stack after drawing
+        cursor.GotoNext(MoveType.After, MatchChatManagerDrawColorString);
+        cursor.EmitLdloc1();
+        cursor.EmitLdloc(origStack);
+        cursor.EmitStfld(typeof(Item).GetField(nameof(Item.stack))!);
+    }
+    #endregion
+
+    public override void Load()
+    {
+        IL_ItemSlot.HandleShopSlot += OnBoughtInSlotHook;
+        IL_ItemSlot.Draw_SpriteBatch_ItemArray_int_int_Vector2_Color += DrawStockedStackHook;
+        IL_Chest.AddItemToShop += SellbackItemHook;
+    }
+}

--- a/Stock/StockHooks.cs
+++ b/Stock/StockHooks.cs
@@ -130,7 +130,9 @@ internal class StockHooks : ModSystem
         cursor.EmitDelegate((Item i) =>
         {
             var stack = i.stack;
-            i.stack = i.GetGlobalItem<StockedItem>().Stack;
+            var stockedItem = i.GetGlobalItem<StockedItem>();
+            if (stockedItem.Stockable)
+                i.stack = stockedItem.Stack;
             return stack;
         });
         cursor.EmitStloc(origStack);

--- a/Stock/StockedItem.cs
+++ b/Stock/StockedItem.cs
@@ -1,0 +1,23 @@
+﻿using Terraria;
+using Terraria.ModLoader;
+
+namespace StockableShops.Stock;
+
+/// <summary>
+/// handle items in a stocked shop
+/// </summary>
+public sealed class StockedItem : GlobalItem
+{
+    /// <inheritdoc/>
+    public override bool InstancePerEntity => true;
+
+    /// <summary>
+    /// set this to true to mark the item in a stocked shop
+    /// </summary>
+    public bool Stockable { get; set; }
+
+    /// <summary>
+    /// use this to storage stack in a stocked shop instead of <see cref="Item.stack"/>
+    /// </summary>
+    public int Stack { get; set; }
+}

--- a/Stock/StockedShop.cs
+++ b/Stock/StockedShop.cs
@@ -289,12 +289,7 @@ public abstract class StockedShop : ModType
         /// Creates an instance of <see cref="ShopItem"/> with the given item and a condition that is always true.
         /// </summary>
         /// <param name="item">The item that this holds.</param>
-        public ShopItem(Item item)
-        {
-            Condition = AlwaysTrue;
-            Item = item;
-            Item.isAShopItem = true;
-        }
+        public ShopItem(Item item) : this(AlwaysTrue, item) { }
 
         /// <summary>
         /// Creates an instance of <see cref="ShopItem"/> with the given condition and item.
@@ -305,7 +300,11 @@ public abstract class StockedShop : ModType
         {
             Condition = condition;
             Item = item;
-            Item.buyOnce = true;
+            Item.isAShopItem = true;
+            var stockedItem = Item.GetGlobalItem<StockedItem>();
+            stockedItem.Stack = Item.stack;
+            stockedItem.Stockable = true;
+            Item.stack = 1;
         }
 
         /// <summary>
@@ -313,12 +312,7 @@ public abstract class StockedShop : ModType
         /// </summary>
         /// <param name="condition">The condition to check, i.e. <c>() => Main.dayTime;</c>.</param>
         /// <param name="item">The item that this holds.</param>
-        public ShopItem(Func<bool> condition, Item item)
-        {
-            Condition = new(string.Empty, condition);
-            Item = item;
-            Item.buyOnce = true;
-        }
+        public ShopItem(Func<bool> condition, Item item) : this(new Condition(string.Empty, condition), item) { }
     }
 
     /// <summary>

--- a/StockableShops.csproj
+++ b/StockableShops.csproj
@@ -1,9 +1,10 @@
-
+﻿
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\tModLoader.targets" />
   <PropertyGroup>
     <AssemblyName>StockableShops</AssemblyName>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="changelog.txt" />


### PR DESCRIPTION
Use another way rather than set the item to buyOnce to prevent the side effects (includes lower price, opposite mood's affection, count as sell-back...).
This PR add some hooks to make the item consumable in shop, and use a GlobalItem to store the stack, to prevent the wrong value tooltip and ItemShopSellbackHelper mistake (if a shop item is IsAShopItem and its stack is not 1, Main.shopSellbackHelper would count it in a wrong way (see ItemShopSellbackHelper.Add at ItemSlot.HandleShopSlot)).
And this also handle the draw of stockable items' stack, even if it's 1 or 0.
Sellback is also supported.
![StockableShops](https://github.com/user-attachments/assets/19a1f8c5-c2ce-4ce7-a513-934c78658e94)
